### PR TITLE
Correct link to Developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you're interested in developing a mode for Glǽmscribe, please read [**_the m
 Installation and integration
 ----------------------------
 
-Here is [**_the installation and integration documentation_**](http://bentalagan.github.com/glaemscribe), for advanced users.
+Here is [**_the installation and integration documentation_**](https://bentalagan.github.io/glaemscribe/), for advanced users.
 
 Changelog
 ---------


### PR DESCRIPTION
The developer docs are actually on github.io, not github.com - correct this. Took me a while to find these so should help other users...